### PR TITLE
Fixed internal calling order of FindTokenAsync

### DIFF
--- a/src/MR.AspNet.Identity.EntityFramework6/UserStore.cs
+++ b/src/MR.AspNet.Identity.EntityFramework6/UserStore.cs
@@ -1072,7 +1072,7 @@ namespace MR.AspNet.Identity.EntityFramework6
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
 		/// <returns>The user token if it exists.</returns>
 		protected Task<TUserToken> FindTokenAsync(TUser user, string loginProvider, string name, CancellationToken cancellationToken)
-			=> UserTokens.FindAsync(new object[] { user.Id, loginProvider, name }, cancellationToken);
+			=> UserTokens.FindAsync(cancellationToken, new object[] { user.Id, loginProvider, name );
 
 		/// <summary>
 		/// Add a new user token.

--- a/src/MR.AspNet.Identity.EntityFramework6/UserStore.cs
+++ b/src/MR.AspNet.Identity.EntityFramework6/UserStore.cs
@@ -1072,7 +1072,7 @@ namespace MR.AspNet.Identity.EntityFramework6
 		/// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
 		/// <returns>The user token if it exists.</returns>
 		protected Task<TUserToken> FindTokenAsync(TUser user, string loginProvider, string name, CancellationToken cancellationToken)
-			=> UserTokens.FindAsync(cancellationToken, new object[] { user.Id, loginProvider, name );
+			=> UserTokens.FindAsync(cancellationToken, new object[] { user.Id, loginProvider, name });
 
 		/// <summary>
 		/// Add a new user token.


### PR DESCRIPTION
FindAsync expects the first parameter to be the cancellationToken. Currently all calls to FindTokenAsync fail due to it calling FindAsync(params object[] keyValues).